### PR TITLE
Build Person 1 Data & Edge demo layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # MongoDB Atlas
-MONGODB_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/careflow?retryWrites=true&w=majority
+MONGODB_URI=
 MONGODB_DB_NAME=careflow
 MONGODB_CONNECT_TIMEOUT_MS=5000
 
@@ -18,10 +18,11 @@ AGENT_COORDINATOR_ADDRESS=agent1q_FILL_AFTER_FIRST_RUN
 
 # ZETIC Melange
 ZETIC_API_KEY=your_zetic_api_key
-ZETIC_DEVICE_ID=careflow-demo-device-001
+ZETIC_MODE=mock
+DEVICE_ID=careflow_watch_001
+ZETIC_DEVICE_ID=careflow_watch_001
 ZETIC_MODEL_KEY=your_melange_model_key
 ZETIC_PERSONAL_KEY=your_melange_personal_key
-ZETIC_BACKEND=heuristic
 
 # FastAPI
 API_HOST=0.0.0.0
@@ -30,5 +31,6 @@ API_BASE_URL=http://localhost:8000
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # Demo
-ANOMALY_THRESHOLD=0.65
+DEFAULT_PATIENT_ID=patient-001
 DEMO_PATIENT_ID=patient-001
+ANOMALY_THRESHOLD=0.65

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Install dependencies (from repo root)
 pip install -r requirements.txt
 
-# Seed demo patients into MongoDB (required before first run)
+# Seed the demo patient into MongoDB (required before first run)
 python scripts/seed.py
 
 # Start everything at once
@@ -38,20 +38,23 @@ curl -X POST http://localhost:8000/trigger-anomaly \
 
 ## Architecture
 
-CareFlow is a linear event pipeline: **Vitals → ZETIC Alert → Gemini Assessment → Dashboard**.
+CareFlow is a linear event pipeline: **Vitals Generator → ZETIC Edge Detection → AnomalyEvent → Gemini/Agent Assessment → Dashboard**.
 
 All Python modules run from the repo root and use `sys.path.insert(0, "..")` so imports are always relative to root (e.g. `from models.schemas import ...`, not relative imports).
 
 ### Data flow
 
 ```
-vitals/generator.py  ──1 Hz──▶  zetic/melange_agent.py  ──AnomalyEvent──▶
-agents/agent1_monitor.py  ──Fetch.ai Chat Protocol──▶  agents/agent2_coordinator.py
-  ──risk/classifier.py (Gemini)──▶  POST /internal/broadcast  ──▶  WebSocket /ws
-  ──▶  careflow-ui (React)
+vitals/generator.py  ──1 Hz──▶  vitals/api.py SSE /vitals/stream/{patient_id}
+  └──▶  zetic/melange_agent.py  ──AnomalyEvent──▶  Mongo anomaly_events
+
+Optional agent path:
+agents/agent1_monitor.py  ──ZETIC/process_vitals──▶  Fetch.ai Chat Protocol
+  ──▶ agents/agent2_coordinator.py ──▶ risk/classifier.py (Gemini)
+  ──▶ POST /internal/broadcast ──▶ WebSocket /ws ──▶ careflow-ui (React)
 ```
 
-The demo trigger (`POST /trigger-anomaly`) mutates a module-level `_anomaly_until` float in `vitals/generator.py`; all subsequent calls to `generate_vitals()` read this flag and produce elevated values.
+The demo trigger (`POST /trigger-anomaly`) updates per-patient in-memory state in `vitals/generator.py`. The next vitals reading for that patient immediately spikes HR, dips SpO2, and drops HRV for the demo window before smoothly recovering.
 
 ### Key design decisions
 
@@ -59,14 +62,19 @@ The demo trigger (`POST /trigger-anomaly`) mutates a module-level `_anomaly_unti
 
 **Coordinator-to-dashboard bridge.** The Coordinator agent is a separate process from FastAPI, so it cannot call `manager.broadcast()` directly. It POSTs to `POST /internal/broadcast` (FastAPI), which calls the WebSocket manager. This is the glue between the agent world and the UI world.
 
-**Fallbacks everywhere.** `zetic/melange_agent.py` falls back to a z-score heuristic if the ZETIC SDK isn't installed. `risk/classifier.py` falls back to rule-based thresholds if Vertex AI fails. Both paths produce identical output types.
+**Fallbacks everywhere.** `zetic/melange_agent.py` falls back to a deterministic threshold scorer if the ZETIC SDK isn't installed or `ZETIC_MODE=mock`. `risk/classifier.py` falls back to rule-based thresholds if Vertex AI fails. Both paths produce identical output types.
 
-**Shared Pydantic models vs Fetch.ai models.** `models/schemas.py` holds Pydantic v2 models used throughout Python. `agents/message_types.py` holds separate `uagents.Model` subclasses required by the Fetch.ai Chat Protocol — the Coordinator manually converts between them.
+**Shared Pydantic models vs Fetch.ai models.** `models/vitals.py` holds the canonical `VitalsPayload` and `AnomalyEvent` models. `models/schemas.py` re-exports those vitals models and keeps risk/action models used by downstream code. `agents/message_types.py` holds separate `uagents.Model` subclasses required by the Fetch.ai Chat Protocol — the Coordinator manually converts between them.
+
+**Mongo collections stay simple.** Person 1's data layer uses only `patients`, `vitals_history`, and `anomaly_events`. The seeded demo patient is `patient-001` / Margaret Chen.
 
 ### Environment setup
 
 Copy `.env.example` → `.env` and fill in:
 - `MONGODB_URI` — Atlas M0 connection string
+- `DEFAULT_PATIENT_ID=patient-001`
+- `DEVICE_ID=careflow_watch_001`
+- `ZETIC_MODE=mock` for the demo-compatible detector fallback
 - `GCP_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS` — for Gemini
 - `AGENT_MONITOR_SEED` / `AGENT_COORDINATOR_SEED` — deterministic agent identity; print the generated address on first run and set `AGENT_MONITOR_ADDRESS` / `AGENT_COORDINATOR_ADDRESS`
 - `ZETIC_MODEL_KEY` / `ZETIC_PERSONAL_KEY` — only needed if using real ZETIC SDK (heuristic fallback works without these)
@@ -75,4 +83,4 @@ Copy `.env.example` → `.env` and fill in:
 - **D** — toggle Demo Controls overlay (Trigger Anomaly button)
 - **F** — toggle System Flow Diagram (for judge pitch)
 
-WebSocket events from the backend all have shape `{ type: string, data: object }`. Currently the only event type is `"risk_assessment"`.
+SSE vitals events from `/vitals/stream/{patient_id}` have shape `{ type: "vitals", data: VitalsPayload }`, with named `"anomaly"` SSE events carrying `{ type: "anomaly", data: AnomalyEvent }`. WebSocket events from the backend all have shape `{ type: string, data: object }`; the main dashboard WebSocket event type remains `"risk_assessment"`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# CareFlow
+
+## Person 1: Data & Edge Layer
+
+This layer generates synthetic wearable vitals, runs local anomaly detection through a ZETIC Melange-compatible wrapper, stores demo data in MongoDB Atlas, and streams live vitals to the dashboard with Server-Sent Events.
+
+### Install
+
+```bash
+pip install -r requirements.txt
+```
+
+Create `.env` from `.env.example` and set `MONGODB_URI`.
+
+### Seed Demo Data
+
+```bash
+python scripts/seed.py
+```
+
+This resets the demo data for `patient-001`, inserts Margaret Chen, and adds 20 normal vitals readings.
+
+### Start The API
+
+```bash
+uvicorn api.main:app --reload --port 8000
+```
+
+Startup logs should show Mongo, demo patient, vitals stream, and trigger endpoint readiness.
+
+### Open The SSE Stream
+
+```bash
+curl -N http://localhost:8000/vitals/stream/patient-001
+```
+
+Each vitals event is shaped as:
+
+```json
+{"type":"vitals","data":{"patient_id":"patient-001","heart_rate":74,"spo2":98,"hrv":55}}
+```
+
+### Trigger Anomaly
+
+```bash
+curl -X POST http://localhost:8000/trigger-anomaly \
+  -H "Content-Type: application/json" \
+  -d '{"patient_id":"patient-001"}'
+```
+
+Within 1-2 seconds, heart rate spikes, SpO2 dips, HRV drops, and the local detector emits an `AnomalyEvent`.
+
+### Pitch
+
+“CareFlow processes raw wearable vitals locally on-device using the ZETIC edge layer. The raw stream never needs to leave the device for initial detection. Once the local model detects a clinically relevant deviation, it sends only a compact anomaly event to the cloud AI pipeline for risk assessment and doctor-facing summarization.”

--- a/agents/agent1_monitor.py
+++ b/agents/agent1_monitor.py
@@ -25,7 +25,7 @@ from vitals.generator import generate_vitals
 from zetic.melange_agent import process_vitals
 
 AGENT_SEED = os.getenv("AGENT_MONITOR_SEED", "careflow-monitor-agent-seed-phrase-001")
-DEMO_PATIENT_ID = os.getenv("DEMO_PATIENT_ID", "patient-001")
+DEMO_PATIENT_ID = os.getenv("DEMO_PATIENT_ID", os.getenv("DEFAULT_PATIENT_ID", "patient-001"))
 
 monitor_agent = Agent(
     name="CareFlow-VitalMonitor",

--- a/agents/agent2_coordinator.py
+++ b/agents/agent2_coordinator.py
@@ -13,9 +13,6 @@ import os
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from datetime import datetime, timezone
-from uuid import UUID, uuid4
-
 import httpx
 from dotenv import load_dotenv
 load_dotenv()
@@ -88,10 +85,10 @@ async def handle_anomaly(ctx: Context, sender: str, msg: AnomalyMessage):
         heart_rate=msg.heart_rate,
         spo2=msg.spo2,
         hrv=msg.hrv,
-        device_id="careflow-demo-device-001",
+        device_id=os.getenv("DEVICE_ID", "careflow_watch_001"),
     )
     anomaly_event = AnomalyEvent(
-        anomaly_id=UUID(msg.anomaly_id),
+        anomaly_id=msg.anomaly_id,
         patient_id=msg.patient_id,
         signal_type=msg.signal_type,
         deviation_score=msg.deviation_score,

--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@
 Endpoints:
   GET  /patients                          — list demo patients
   GET  /vitals/stream/{patient_id}        — SSE live vitals (proxied from vitals.api)
-  GET  /vitals/latest/{patient_id}        — single vitals reading
+  GET  /vitals/current/{patient_id}       — latest vitals reading
   POST /trigger-anomaly                   — inject demo anomaly
   GET  /agents/status                     — heartbeat for both agents
   POST /internal/broadcast               — called by Coordinator agent to push WS events
@@ -22,6 +22,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from api.ws_manager import manager
+from db.db import get_db, seed_demo_patient_if_missing
 from vitals.api import router as vitals_router
 
 app = FastAPI(title="CareFlow API", version="1.0.0")
@@ -68,6 +69,20 @@ DEMO_PATIENTS = [
 ]
 
 
+@app.on_event("startup")
+async def startup() -> None:
+    try:
+        get_db().command("ping")
+        print("[CareFlow] Mongo connected")
+        seed_demo_patient_if_missing()
+        print("[CareFlow] Demo patient ready")
+    except Exception as exc:
+        print(f"[CareFlow] Mongo startup skipped: {exc}")
+
+    print("[CareFlow] Vitals stream ready: GET /vitals/stream/patient-001")
+    print("[CareFlow] Trigger endpoint ready: POST /trigger-anomaly")
+
+
 @app.get("/patients")
 async def list_patients():
     return DEMO_PATIENTS
@@ -101,8 +116,3 @@ async def websocket_endpoint(ws: WebSocket):
             await ws.receive_text()  # keep connection alive
     except WebSocketDisconnect:
         manager.disconnect(ws)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}

--- a/careflow-ui/src/App.jsx
+++ b/careflow-ui/src/App.jsx
@@ -64,9 +64,17 @@ export default function App() {
   useEffect(() => {
     const es = new EventSource(`${API_BASE}/vitals/stream/${SELECTED_PATIENT}`)
     es.onmessage = (e) => {
-      const payload = JSON.parse(e.data)
+      const event = JSON.parse(e.data)
+      const payload = event.type === 'vitals' ? event.data : event
       setVitals((prev) => [...prev.slice(-59), { ...payload, time: new Date(payload.timestamp).toLocaleTimeString() }])
     }
+    es.addEventListener('anomaly', (e) => {
+      const event = JSON.parse(e.data)
+      if (event.type === 'anomaly') {
+        setFlashRed(true)
+        setTimeout(() => setFlashRed(false), 1600)
+      }
+    })
     return () => es.close()
   }, [])
 

--- a/db/db.py
+++ b/db/db.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
+
 import os
 from datetime import datetime, timezone
 from typing import Optional
 
+from dotenv import load_dotenv
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo import MongoClient
+from pymongo.database import Database
+
+from models.vitals import AnomalyEvent, VitalsPayload
+
+load_dotenv()
+
+DEMO_PATIENT = {
+    "patient_id": "patient-001",
+    "name": "Margaret Chen",
+    "age": 67,
+    "conditions": ["Atrial Fibrillation", "Hypertension"],
+    "baseline_hr": 72,
+    "baseline_spo2": 98.5,
+    "baseline_hrv": 58,
+    "device_id": "careflow_watch_001",
+}
 
 _async_client: Optional[AsyncIOMotorClient] = None
 _sync_client: Optional[MongoClient] = None
@@ -12,36 +30,52 @@ _sync_client: Optional[MongoClient] = None
 
 def get_async_db():
     global _async_client
+    mongodb_uri = os.getenv("MONGODB_URI")
+    if not mongodb_uri:
+        raise RuntimeError("MONGODB_URI is not configured")
+
     if _async_client is None:
         _async_client = AsyncIOMotorClient(
-            os.environ["MONGODB_URI"],
+            mongodb_uri,
             serverSelectionTimeoutMS=int(os.getenv("MONGODB_CONNECT_TIMEOUT_MS", "5000")),
         )
     return _async_client[os.getenv("MONGODB_DB_NAME", "careflow")]
 
 
-def get_sync_db():
+def get_sync_db() -> Database:
     global _sync_client
+    mongodb_uri = os.getenv("MONGODB_URI")
+    if not mongodb_uri:
+        raise RuntimeError("MONGODB_URI is not configured")
+
     if _sync_client is None:
         _sync_client = MongoClient(
-            os.environ["MONGODB_URI"],
+            mongodb_uri,
             serverSelectionTimeoutMS=int(os.getenv("MONGODB_CONNECT_TIMEOUT_MS", "5000")),
         )
     return _sync_client[os.getenv("MONGODB_DB_NAME", "careflow")]
 
 
-async def save_vitals(payload: dict) -> None:
-    db = get_async_db()
-    await db.vitals.insert_one({**payload, "saved_at": datetime.now(timezone.utc)})
+def get_db() -> Database:
+    return get_sync_db()
 
 
-async def save_anomaly(event: dict) -> None:
-    db = get_async_db()
-    await db.vitals.update_one(
-        {"patient_id": event["patient_id"]},
-        {"$set": {"latest_anomaly": event, "anomaly_flagged": True}},
-        upsert=True,
-    )
+def _dump_model(model) -> dict:
+    return model.model_dump(mode="python")
+
+
+def save_vitals(payload: VitalsPayload) -> None:
+    db = get_db()
+    doc = _dump_model(payload)
+    doc["saved_at"] = datetime.now(timezone.utc)
+    db.vitals_history.insert_one(doc)
+
+
+def save_anomaly(event: AnomalyEvent) -> None:
+    db = get_db()
+    doc = _dump_model(event)
+    doc["saved_at"] = datetime.now(timezone.utc)
+    db.anomaly_events.insert_one(doc)
 
 
 async def save_assessment(assessment: dict) -> None:
@@ -49,17 +83,35 @@ async def save_assessment(assessment: dict) -> None:
     await db.assessments.insert_one({**assessment, "saved_at": datetime.now(timezone.utc)})
 
 
-async def get_patient(patient_id: str) -> Optional[dict]:
-    db = get_async_db()
-    return await db.patients.find_one({"patient_id": patient_id}, {"_id": 0})
+def get_latest_vitals(patient_id: str) -> Optional[VitalsPayload]:
+    db = get_db()
+    doc = db.vitals_history.find_one(
+        {"patient_id": patient_id},
+        sort=[("timestamp", -1)],
+    )
+    if not doc:
+        return None
+    doc.pop("_id", None)
+    return VitalsPayload.model_validate(doc)
 
 
-async def get_all_patients() -> list[dict]:
-    db = get_async_db()
-    cursor = db.patients.find({}, {"_id": 0})
-    return await cursor.to_list(length=100)
+def seed_demo_patient_if_missing() -> None:
+    db = get_db()
+    existing = db.patients.find_one({"patient_id": DEMO_PATIENT["patient_id"]})
+    if not existing:
+        db.patients.insert_one({**DEMO_PATIENT, "created_at": datetime.now(timezone.utc)})
+
+
+def get_patient(patient_id: str) -> Optional[dict]:
+    db = get_db()
+    doc = db.patients.find_one({"patient_id": patient_id}, {"_id": 0})
+    return doc
 
 
 def get_all_patients_sync() -> list[dict]:
-    db = get_sync_db()
+    db = get_db()
     return list(db.patients.find({}, {"_id": 0}))
+
+
+async def get_all_patients() -> list[dict]:
+    return get_all_patients_sync()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,3 @@
+from models.vitals import AnomalyEvent, VitalsPayload
+
+__all__ = ["AnomalyEvent", "VitalsPayload"]

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -6,6 +6,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from models.vitals import AnomalyEvent, VitalsPayload
+
 
 class SeverityLevel(str, Enum):
     LOW = "LOW"
@@ -21,24 +23,6 @@ class ActionTier(str, Enum):
     ER_DISPATCH = "ER_DISPATCH"
 
 
-class VitalsPayload(BaseModel):
-    patient_id: str
-    heart_rate: float
-    spo2: float
-    hrv: float
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    device_id: str = "careflow-demo-device-001"
-
-
-class AnomalyEvent(BaseModel):
-    anomaly_id: UUID = Field(default_factory=uuid4)
-    patient_id: str
-    signal_type: str = "HR+HRV+SpO2"
-    deviation_score: float
-    vitals_snapshot: VitalsPayload
-    detected_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-
 class RiskAssessment(BaseModel):
     assessment_id: UUID = Field(default_factory=uuid4)
     patient_id: str
@@ -46,7 +30,7 @@ class RiskAssessment(BaseModel):
     severity_level: SeverityLevel
     reasoning_context: str
     doctor_note: str
-    anomaly_ref: UUID
+    anomaly_ref: str
     generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
@@ -55,5 +39,5 @@ class ActionDecision(BaseModel):
     patient_id: str
     action_tier: ActionTier
     provider_message: Optional[str] = None
-    assessment_ref: UUID
+    assessment_ref: str
     executed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/models/vitals.py
+++ b/models/vitals.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class VitalsPayload(BaseModel):
+    patient_id: str
+    timestamp: datetime = Field(default_factory=utc_now)
+    heart_rate: int
+    spo2: int
+    hrv: int
+    device_id: str
+    anomaly_flagged: bool = False
+
+
+class AnomalyEvent(BaseModel):
+    anomaly_id: str = Field(default_factory=lambda: str(uuid4()))
+    patient_id: str
+    signal_type: str
+    deviation_score: float
+    vitals_snapshot: VitalsPayload
+    detected_at: datetime = Field(default_factory=utc_now)
+    source: str = "zetic_on_device"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.111.1
 uvicorn[standard]==0.30.3
 pydantic==2.7.4
 python-dotenv==1.0.1
+sse-starlette==2.1.3
 httpx==0.27.0
 
 # MongoDB

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -1,67 +1,50 @@
-"""Seed demo patients into MongoDB Atlas.
+"""Seed Person 1 demo data into MongoDB Atlas.
 
-Run:  python scripts/seed.py
+Run: python scripts/seed.py
 """
 from __future__ import annotations
+
 import os
 import sys
+import time
+from datetime import datetime, timezone
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from datetime import datetime, timezone
 from dotenv import load_dotenv
-load_dotenv()
-
 from pymongo import MongoClient
 
-PATIENTS = [
-    {
-        "patient_id": "patient-001",
-        "name": "Margaret Chen",
-        "age": 67,
-        "conditions": ["Atrial Fibrillation", "Hypertension"],
-        "medications": ["Metoprolol 25mg", "Lisinopril 10mg", "Warfarin 5mg"],
-        "baseline_hr": 72,
-        "baseline_spo2": 98.5,
-        "baseline_hrv": 58,
-        "notification_prefs": {"channel": "push", "sensitivity": "HIGH"},
-    },
-    {
-        "patient_id": "patient-002",
-        "name": "Robert Okafor",
-        "age": 54,
-        "conditions": ["Type 2 Diabetes", "Coronary Artery Disease"],
-        "medications": ["Metformin 500mg", "Atorvastatin 40mg", "Aspirin 81mg"],
-        "baseline_hr": 68,
-        "baseline_spo2": 97.8,
-        "baseline_hrv": 62,
-        "notification_prefs": {"channel": "push", "sensitivity": "MEDIUM"},
-    },
-    {
-        "patient_id": "patient-003",
-        "name": "Sofia Ramirez",
-        "age": 71,
-        "conditions": ["COPD", "Post-op Cardiac Recovery"],
-        "medications": ["Tiotropium 18mcg", "Prednisone 5mg", "Furosemide 20mg"],
-        "baseline_hr": 78,
-        "baseline_spo2": 96.5,
-        "baseline_hrv": 44,
-        "notification_prefs": {"channel": "voice", "sensitivity": "HIGH"},
-    },
-]
+from db.db import DEMO_PATIENT
+from vitals.generator import generate_next_vitals
+
+load_dotenv()
 
 
-def seed():
+def seed() -> None:
+    patient_id = os.getenv("DEFAULT_PATIENT_ID", "patient-001")
     client = MongoClient(os.environ["MONGODB_URI"])
     db = client[os.getenv("MONGODB_DB_NAME", "careflow")]
 
-    db.patients.drop()
-    result = db.patients.insert_many(PATIENTS)
-    print(f"Seeded {len(result.inserted_ids)} patients")
+    db.patients.delete_many({"patient_id": patient_id})
+    db.vitals_history.delete_many({"patient_id": patient_id})
+    db.anomaly_events.delete_many({"patient_id": patient_id})
 
-    db.vitals.create_index([("patient_id", 1), ("saved_at", -1)])
-    db.assessments.create_index([("patient_id", 1), ("generated_at", -1)])
-    print("Indexes created")
+    db.patients.insert_one(
+        {**DEMO_PATIENT, "patient_id": patient_id, "created_at": datetime.now(timezone.utc)}
+    )
+
+    readings = []
+    for _ in range(20):
+        payload = generate_next_vitals(patient_id)
+        readings.append({**payload.model_dump(mode="python"), "saved_at": datetime.now(timezone.utc)})
+        time.sleep(0.02)
+
+    db.vitals_history.insert_many(readings)
+    db.vitals_history.create_index([("patient_id", 1), ("timestamp", -1)])
+    db.anomaly_events.create_index([("patient_id", 1), ("detected_at", -1)])
     client.close()
+
+    print(f"Seeded CareFlow demo patient {patient_id} with {len(readings)} normal vitals readings.")
 
 
 if __name__ == "__main__":

--- a/start.sh
+++ b/start.sh
@@ -18,7 +18,7 @@ echo "  CareFlow  ·  LA Hacks 2026"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # Seed DB (idempotent — safe to re-run)
-echo "▶ Seeding demo patients…"
+echo "▶ Seeding demo patient…"
 python scripts/seed.py
 
 echo "▶ Starting FastAPI gateway on :8000…"

--- a/vitals/api.py
+++ b/vitals/api.py
@@ -1,19 +1,20 @@
-"""FastAPI router: SSE vitals stream + demo trigger endpoint."""
+"""FastAPI router for live vitals, local edge detection, and demo triggers."""
 from __future__ import annotations
+
 import asyncio
 import json
-import os
 from typing import AsyncGenerator
 
 from fastapi import APIRouter
-from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
 
-from vitals.generator import generate_vitals, trigger_anomaly
+from db.db import save_vitals
+from vitals.generator import generate_next_vitals, trigger_anomaly
+from zetic.melange_agent import ZeticAnomalyDetector
 
 router = APIRouter()
-
-DEMO_PATIENTS = ["patient-001", "patient-002", "patient-003"]
+detector = ZeticAnomalyDetector()
 
 
 class TriggerRequest(BaseModel):
@@ -21,32 +22,59 @@ class TriggerRequest(BaseModel):
     duration_seconds: int = 30
 
 
+def _json_event(event_type: str, data) -> str:
+    return json.dumps(
+        {
+            "type": event_type,
+            "data": data.model_dump(mode="json"),
+        }
+    )
+
+
+@router.get("/health")
+async def data_edge_health():
+    return {"status": "ok", "service": "careflow-data-edge"}
+
+
 @router.post("/trigger-anomaly")
 async def trigger_anomaly_endpoint(req: TriggerRequest):
-    trigger_anomaly(req.duration_seconds)
-    return {"status": "anomaly triggered", "patient_id": req.patient_id, "duration_seconds": req.duration_seconds}
+    return trigger_anomaly(req.patient_id, req.duration_seconds)
 
 
-async def _vitals_event_generator(patient_id: str) -> AsyncGenerator[str, None]:
+@router.get("/vitals/current/{patient_id}")
+async def current_vitals(patient_id: str):
+    return generate_next_vitals(patient_id)
+
+
+@router.get("/vitals/latest/{patient_id}")
+async def latest_vitals(patient_id: str):
+    return await current_vitals(patient_id)
+
+
+async def _vitals_event_generator(patient_id: str) -> AsyncGenerator[dict, None]:
     while True:
-        payload = generate_vitals(patient_id)
-        data = payload.model_dump_json()
-        yield f"data: {data}\n\n"
+        payload = generate_next_vitals(patient_id)
+        anomaly = detector.add_vitals(payload)
+
+        try:
+            save_vitals(payload)
+        except Exception as exc:
+            print(f"[Mongo] vitals save skipped: {exc}")
+
+        yield {"data": _json_event("vitals", payload)}
+
+        if anomaly:
+            yield {"event": "anomaly", "data": _json_event("anomaly", anomaly)}
+
         await asyncio.sleep(1.0)
 
 
 @router.get("/vitals/stream/{patient_id}")
 async def vitals_stream(patient_id: str):
-    return StreamingResponse(
+    return EventSourceResponse(
         _vitals_event_generator(patient_id),
-        media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",
         },
     )
-
-
-@router.get("/vitals/latest/{patient_id}")
-async def latest_vitals(patient_id: str):
-    return generate_vitals(patient_id)

--- a/vitals/generator.py
+++ b/vitals/generator.py
@@ -1,66 +1,122 @@
-"""Synthetic vitals generator — streams VitalsPayload at ~1 Hz.
-
-Normal ranges:  HR 60-90 BPM,  SpO2 97-100%,  HRV 40-80 ms
-Anomaly mode:   HR 120-160 BPM, SpO2 93-96%,   HRV 12-25 ms  (simulates AFib onset)
-"""
+"""Synthetic vitals generator for the CareFlow edge-device demo."""
 from __future__ import annotations
-import asyncio
+
 import math
 import os
 import random
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Callable, Optional
 
-from models.schemas import VitalsPayload
+from models.vitals import VitalsPayload
 
-_anomaly_until: float = 0.0  # epoch seconds
-
-
-def trigger_anomaly(duration_seconds: int = 30) -> None:
-    global _anomaly_until
-    _anomaly_until = time.time() + duration_seconds
+DEFAULT_PATIENT_ID = os.getenv("DEFAULT_PATIENT_ID", os.getenv("DEMO_PATIENT_ID", "patient-001"))
+DEVICE_ID = os.getenv("DEVICE_ID", "careflow_watch_001")
+ANOMALY_DURATION_SECONDS = 30
+RECOVERY_SECONDS = 18
 
 
-def _is_anomaly() -> bool:
-    return time.time() < _anomaly_until
+@dataclass
+class PatientVitalsState:
+    heart_rate: float = 74.0
+    spo2: float = 98.0
+    hrv: float = 55.0
+    anomaly_until: float = 0.0
+    recovery_started_at: float = 0.0
 
 
-def _circadian_offset(t: float) -> float:
-    """Slow sinusoidal rhythm variation — looks organic on a chart."""
-    return 4 * math.sin(2 * math.pi * t / 86400)
+_states: dict[str, PatientVitalsState] = {}
 
 
-def generate_vitals(patient_id: str, device_id: str = "careflow-demo-device-001") -> VitalsPayload:
-    t = time.time()
-    circadian = _circadian_offset(t)
+def _state_for(patient_id: str) -> PatientVitalsState:
+    if patient_id not in _states:
+        _states[patient_id] = PatientVitalsState()
+    return _states[patient_id]
 
-    if _is_anomaly():
-        hr = random.gauss(140, 8) + circadian
-        spo2 = random.gauss(94.5, 0.8)
-        hrv = random.gauss(18, 4)
-    else:
-        hr = random.gauss(72 + circadian, 3)
-        spo2 = random.gauss(98.5, 0.4)
-        hrv = random.gauss(58, 7)
 
-    return VitalsPayload(
-        patient_id=patient_id,
-        heart_rate=round(max(40.0, hr), 1),
-        spo2=round(min(100.0, max(85.0, spo2)), 1),
-        hrv=round(max(5.0, hrv), 1),
-        timestamp=datetime.now(timezone.utc),
-        device_id=device_id,
+def _organic_wave(now: float, period: float, amplitude: float) -> float:
+    return amplitude * math.sin(2 * math.pi * now / period)
+
+
+def _bounded_int(value: float, low: int, high: int) -> int:
+    return int(round(min(high, max(low, value))))
+
+
+def is_anomaly_active(patient_id: str) -> bool:
+    return time.time() < _state_for(patient_id).anomaly_until
+
+
+def trigger_anomaly(patient_id: str = DEFAULT_PATIENT_ID, duration_seconds: int = ANOMALY_DURATION_SECONDS) -> dict:
+    if isinstance(patient_id, int):
+        duration_seconds = patient_id
+        patient_id = DEFAULT_PATIENT_ID
+
+    state = _state_for(patient_id)
+    state.anomaly_until = time.time() + duration_seconds
+    state.recovery_started_at = 0.0
+    return {
+        "status": "triggered",
+        "patient_id": patient_id,
+        "message": f"Anomaly mode active for {duration_seconds} seconds",
+    }
+
+
+def _target_values(patient_id: str, now: float) -> tuple[float, float, float, float]:
+    state = _state_for(patient_id)
+
+    if now < state.anomaly_until:
+        state.recovery_started_at = 0.0
+        return (
+            random.uniform(125, 155),
+            random.uniform(91, 95),
+            random.uniform(10, 24),
+            1.0,
+        )
+
+    if state.anomaly_until > 0:
+        if state.recovery_started_at == 0.0:
+            state.recovery_started_at = now
+        elapsed = now - state.recovery_started_at
+        if elapsed < RECOVERY_SECONDS:
+            recovery = elapsed / RECOVERY_SECONDS
+            return (
+                140 - (64 * recovery) + random.uniform(-2, 2),
+                93 + (5 * recovery) + random.uniform(-0.3, 0.3),
+                18 + (37 * recovery) + random.uniform(-2, 2),
+                0.28,
+            )
+        state.anomaly_until = 0.0
+        state.recovery_started_at = 0.0
+
+    return (
+        74 + _organic_wave(now, 31, 4) + random.uniform(-3, 3),
+        98.5 + _organic_wave(now, 43, 0.5) + random.uniform(-0.4, 0.4),
+        58 + _organic_wave(now, 37, 6) + random.uniform(-5, 5),
+        0.35,
     )
 
 
-async def stream_vitals(
-    patient_id: str,
-    callback: Callable[[VitalsPayload], None],
-    interval: float = 1.0,
-) -> None:
-    """Indefinitely generate vitals and call callback at each tick."""
-    while True:
-        payload = generate_vitals(patient_id)
-        callback(payload)
-        await asyncio.sleep(interval)
+def generate_next_vitals(patient_id: str) -> VitalsPayload:
+    state = _state_for(patient_id)
+    now = time.time()
+    target_hr, target_spo2, target_hrv, smoothing = _target_values(patient_id, now)
+
+    state.heart_rate += (target_hr - state.heart_rate) * smoothing
+    state.spo2 += (target_spo2 - state.spo2) * smoothing
+    state.hrv += (target_hrv - state.hrv) * smoothing
+
+    return VitalsPayload(
+        patient_id=patient_id,
+        timestamp=datetime.now(timezone.utc),
+        heart_rate=_bounded_int(state.heart_rate, 45, 170),
+        spo2=_bounded_int(state.spo2, 85, 100),
+        hrv=_bounded_int(state.hrv, 5, 90),
+        device_id=DEVICE_ID,
+    )
+
+
+def generate_vitals(patient_id: str, device_id: str | None = None) -> VitalsPayload:
+    payload = generate_next_vitals(patient_id)
+    if device_id:
+        payload.device_id = device_id
+    return payload

--- a/zetic/melange_agent.py
+++ b/zetic/melange_agent.py
@@ -1,85 +1,111 @@
-"""ZETIC Melange on-device anomaly detector.
+"""ZETIC Melange-compatible local anomaly detector.
 
-Buffers the last 10s of vitals. On each tick, runs inference and emits
-AnomalyEvent when deviation_score exceeds ANOMALY_THRESHOLD.
-
-If the ZETIC SDK is unavailable (dev/CI), falls back to a heuristic scorer
-that produces equivalent outputs for testing the rest of the pipeline.
+The demo contract is intentionally small: raw vitals are processed locally,
+and only compact AnomalyEvent objects are saved/sent upstream.
 """
 from __future__ import annotations
+
 import os
-import time
-from collections import deque
-from typing import Callable, Optional
-from uuid import uuid4
+from collections import defaultdict, deque
+from typing import Deque, Optional
 
-from models.schemas import AnomalyEvent, VitalsPayload
-
-ANOMALY_THRESHOLD = float(os.getenv("ANOMALY_THRESHOLD", "0.65"))
-BUFFER_SIZE = 10  # seconds of vitals to buffer
+from db.db import save_anomaly
+from models.vitals import AnomalyEvent, VitalsPayload
 
 
-class MelangeDetector:
+class ZeticAnomalyDetector:
+    buffer_size = 10
+    threshold = float(os.getenv("ANOMALY_THRESHOLD", "0.65"))
+
     def __init__(self) -> None:
-        self._buffer: deque[VitalsPayload] = deque(maxlen=BUFFER_SIZE)
+        self._buffers: dict[str, Deque[VitalsPayload]] = defaultdict(
+            lambda: deque(maxlen=self.buffer_size)
+        )
+        self._zetic_model = None
         self._zetic_available = self._try_init_zetic()
 
     def _try_init_zetic(self) -> bool:
-        try:
-            from zetic_mlange import ZeticMLange  # type: ignore
-            model_key = os.environ["ZETIC_MODEL_KEY"]
-            personal_key = os.environ["ZETIC_PERSONAL_KEY"]
-            backend = os.getenv("ZETIC_BACKEND", "heuristic")
-            self._model = ZeticMLange(model_key, personal_key, backend=backend)
-            print("[ZETIC] Melange SDK initialised successfully")
-            return True
-        except Exception as exc:
-            print(f"[ZETIC] SDK not available ({exc}) — using heuristic fallback")
+        if os.getenv("ZETIC_MODE", "mock").lower() == "mock":
             return False
 
-    def _heuristic_score(self) -> float:
-        """Simple z-score based deviation across HR, SpO2, HRV."""
-        if len(self._buffer) < 3:
-            return 0.0
-        hrs = [v.heart_rate for v in self._buffer]
-        spo2s = [v.spo2 for v in self._buffer]
-        hrvs = [v.hrv for v in self._buffer]
+        try:
+            # TODO: Replace this import and constructor with the confirmed
+            # ZETIC Melange SDK package from the LA Hacks starter pack.
+            from zetic_melange import ZeticMelange  # type: ignore
 
-        def z(vals: list[float]) -> float:
-            mean = sum(vals) / len(vals)
-            std = (sum((x - mean) ** 2 for x in vals) / len(vals)) ** 0.5
-            return abs(vals[-1] - mean) / (std + 1e-6)
+            self._zetic_model = ZeticMelange(
+                model_key=os.environ["ZETIC_MODEL_KEY"],
+                personal_key=os.environ["ZETIC_PERSONAL_KEY"],
+            )
+            print("[ZETIC] Melange SDK initialized")
+            return True
+        except Exception as exc:
+            print(f"[ZETIC] SDK unavailable ({exc}); using deterministic mock scorer")
+            return False
 
-        # Normalise to [0, 1] — a z-score of 3+ maps to ~1.0
-        score = min(1.0, (z(hrs) * 0.5 + z(spo2s) * 0.3 + z(hrvs) * 0.2) / 3.0)
-        return round(score, 4)
+    def add_vitals(self, payload: VitalsPayload) -> Optional[AnomalyEvent]:
+        recent_buffer = self._buffers[payload.patient_id]
+        score = self.calculate_deviation_score(payload, recent_buffer)
+        recent_buffer.append(payload)
 
-    def _zetic_score(self) -> float:
-        if len(self._buffer) < BUFFER_SIZE:
-            return 0.0
+        if score < self.threshold:
+            return None
+
+        payload.anomaly_flagged = True
+        event = AnomalyEvent(
+            patient_id=payload.patient_id,
+            signal_type="HR+SpO2+HRV",
+            deviation_score=score,
+            vitals_snapshot=payload,
+        )
+
+        try:
+            save_anomaly(event)
+        except Exception as exc:
+            print(f"[Mongo] anomaly save skipped: {exc}")
+
+        return event
+
+    def calculate_deviation_score(
+        self,
+        payload: VitalsPayload,
+        recent_buffer: Deque[VitalsPayload],
+    ) -> float:
+        if self._zetic_available:
+            # TODO: Replace this adapter with real ZETIC Melange on-device
+            # inference once the SDK/model artifact is available.
+            return self._calculate_zetic_score(payload, recent_buffer)
+
+        score = 0.0
+        if payload.heart_rate > 120:
+            score += 0.45
+        if payload.spo2 < 95:
+            score += 0.25
+        if payload.hrv < 30:
+            score += 0.25
+        if recent_buffer:
+            avg_hr = sum(v.heart_rate for v in recent_buffer) / len(recent_buffer)
+            if payload.heart_rate - avg_hr > 25:
+                score += 0.15
+        return round(min(score, 1.0), 4)
+
+    def _calculate_zetic_score(
+        self,
+        payload: VitalsPayload,
+        recent_buffer: Deque[VitalsPayload],
+    ) -> float:
         sequence = [
             [v.heart_rate, v.spo2, v.hrv]
-            for v in self._buffer
+            for v in [*recent_buffer, payload][-self.buffer_size :]
         ]
-        result = self._model.infer({"input": sequence})
+        # TODO: Confirm exact SDK input/output names. The fallback scorer keeps
+        # the same public interface for the rest of the demo pipeline.
+        result = self._zetic_model.infer({"vitals": sequence})
         return float(result.get("deviation_score", 0.0))
 
-    def ingest(self, payload: VitalsPayload) -> Optional[AnomalyEvent]:
-        self._buffer.append(payload)
-        score = self._zetic_score() if self._zetic_available else self._heuristic_score()
 
-        if score >= ANOMALY_THRESHOLD:
-            return AnomalyEvent(
-                patient_id=payload.patient_id,
-                deviation_score=score,
-                vitals_snapshot=payload,
-            )
-        return None
-
-
-_detector = MelangeDetector()
+_detector = ZeticAnomalyDetector()
 
 
 def process_vitals(payload: VitalsPayload) -> Optional[AnomalyEvent]:
-    """Public interface used by Agent 1."""
-    return _detector.ingest(payload)
+    return _detector.add_vitals(payload)


### PR DESCRIPTION
## Summary
- Add Person 1 Data & Edge implementation for the CareFlow demo
- Generate live synthetic vitals for `patient-001`
- Add `POST /trigger-anomaly` to simulate a visible anomaly on demand
- Add ZETIC-compatible local anomaly detector with mock fallback scoring
- Stream typed vitals/anomaly events over SSE
- Persist vitals and anomaly events to MongoDB while preserving existing boilerplate helpers
- Update frontend SSE handling so the dashboard can consume typed vitals events

## Notes
- Preserves the existing `/patients` boilerplate list with all 3 demo patients
- Uses `patient-001` as the canonical demo patient
- Keeps the implementation demo-first and avoids benchmarking or complex history logic

## Test Plan
- `python3 -m compileall api db models vitals zetic scripts agents risk`
- `POST /trigger-anomaly` with `patient-001`
- `GET /vitals/current/patient-001`
- Confirmed SSE generator emits typed `vitals` and `anomaly` events
- `npm --prefix careflow-ui run build`