### PR TITLE
Gemma and api work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,10 @@ MONGODB_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/careflow?retry
 MONGODB_DB_NAME=careflow
 MONGODB_CONNECT_TIMEOUT_MS=5000
 
-# Google Cloud / Vertex AI
-GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account-key.json
-GCP_PROJECT_ID=your-gcp-project-id
-GCP_REGION=us-central1
-VERTEX_AI_MODEL=gemini-pro
+# Gemma via Ollama (local, no API key needed)
+# Setup: brew install ollama && ollama pull gemma2:2b && ollama serve
+OLLAMA_HOST=http://localhost:11434
+GEMMA_MODEL=gemma2:2b
 
 # Fetch.ai Agentverse — two agents
 AGENT_MONITOR_SEED=careflow-monitor-agent-seed-phrase-001

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The demo trigger (`POST /trigger-anomaly`) mutates a module-level `_anomaly_unti
 
 **Coordinator-to-dashboard bridge.** The Coordinator agent is a separate process from FastAPI, so it cannot call `manager.broadcast()` directly. It POSTs to `POST /internal/broadcast` (FastAPI), which calls the WebSocket manager. This is the glue between the agent world and the UI world.
 
-**Fallbacks everywhere.** `zetic/melange_agent.py` falls back to a z-score heuristic if the ZETIC SDK isn't installed. `risk/classifier.py` falls back to rule-based thresholds if Vertex AI fails. Both paths produce identical output types.
+**Fallbacks everywhere.** `zetic/melange_agent.py` falls back to a z-score heuristic if the ZETIC SDK isn't installed. `risk/classifier.py` falls back to rule-based thresholds if the Gemini API fails. Both paths produce identical output types.
 
 **Shared Pydantic models vs Fetch.ai models.** `models/schemas.py` holds Pydantic v2 models used throughout Python. `agents/message_types.py` holds separate `uagents.Model` subclasses required by the Fetch.ai Chat Protocol — the Coordinator manually converts between them.
 
@@ -67,7 +67,7 @@ The demo trigger (`POST /trigger-anomaly`) mutates a module-level `_anomaly_unti
 
 Copy `.env.example` → `.env` and fill in:
 - `MONGODB_URI` — Atlas M0 connection string
-- `GCP_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS` — for Gemini
+- `OLLAMA_HOST` / `GEMMA_MODEL` — Ollama must be running locally (`ollama serve`); default model is `gemma2:2b`
 - `AGENT_MONITOR_SEED` / `AGENT_COORDINATOR_SEED` — deterministic agent identity; print the generated address on first run and set `AGENT_MONITOR_ADDRESS` / `AGENT_COORDINATOR_ADDRESS`
 - `ZETIC_MODEL_KEY` / `ZETIC_PERSONAL_KEY` — only needed if using real ZETIC SDK (heuristic fallback works without these)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core
 fastapi==0.111.1
 uvicorn[standard]==0.30.3
-pydantic==2.7.4
+pydantic>=2.8,<3.0
 python-dotenv==1.0.1
 httpx==0.27.0
 
@@ -10,11 +10,9 @@ motor==3.4.0
 pymongo==4.8.0
 
 # Fetch.ai agents
-uagents==0.13.0
+uagents==0.24.2
 
-# Google Cloud / Vertex AI
-google-cloud-aiplatform==1.59.0
-vertexai==1.59.0
+# Gemma via Ollama (httpx already listed above — no extra deps needed)
 
 # ZETIC Melange (install separately if SDK available)
 # zetic_mlange  -- pip install from ZETIC docs / starter pack

--- a/risk/classifier.py
+++ b/risk/classifier.py
@@ -1,7 +1,7 @@
-"""Gemini risk classifier — converts an AnomalyEvent into a RiskAssessment.
+"""Gemma risk classifier — converts an AnomalyEvent into a RiskAssessment.
 
-Uses Vertex AI (Gemini) with a single structured prompt. Falls back to a
-rule-based assessment when Vertex AI is unavailable (dev/offline mode).
+Uses a locally-running Gemma model via Ollama with a single structured prompt.
+Falls back to rule-based assessment when Ollama is unavailable (dev/offline mode).
 """
 from __future__ import annotations
 import json
@@ -19,13 +19,8 @@ Patient vitals anomaly:
 - Deviation Score: {deviation_score} (threshold: 0.65)
 - Signal Type: {signal_type}
 
-Respond ONLY with a valid JSON object in this exact format:
-{{
-  "risk_score": <float 0.0-1.0>,
-  "severity_level": "<LOW|MEDIUM|HIGH|CRITICAL>",
-  "reasoning_context": "<2-3 sentence clinical explanation of what the vitals suggest>",
-  "doctor_note": "<1 sentence recommended immediate action for the care provider>"
-}}
+Respond ONLY with a valid JSON object. No explanation, no markdown, no code fences. Just the raw JSON:
+{{"risk_score": <float 0.0-1.0>, "severity_level": "<LOW|MEDIUM|HIGH|CRITICAL>", "reasoning_context": "<2-3 sentence clinical explanation>", "doctor_note": "<1 sentence recommended action>"}}
 
 Rules:
 - risk_score < 0.4 → LOW, 0.4-0.6 → MEDIUM, 0.6-0.8 → HIGH, > 0.8 → CRITICAL
@@ -64,28 +59,28 @@ def _rule_based_fallback(event: AnomalyEvent) -> dict:
     }
 
 
-def _call_gemini(prompt: str) -> Optional[dict]:
+def _call_gemma(prompt: str) -> Optional[dict]:
     try:
-        import vertexai  # type: ignore
-        from vertexai.generative_models import GenerativeModel  # type: ignore
+        import httpx
 
-        project = os.environ["GCP_PROJECT_ID"]
-        region = os.getenv("GCP_REGION", "us-central1")
-        model_name = os.getenv("VERTEX_AI_MODEL", "gemini-pro")
+        ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        model_name = os.getenv("GEMMA_MODEL", "gemma2:2b")
 
-        vertexai.init(project=project, location=region)
-        model = GenerativeModel(model_name)
-        response = model.generate_content(prompt)
-        text = response.text.strip()
+        response = httpx.post(
+            f"{ollama_host}/api/generate",
+            json={"model": model_name, "prompt": prompt, "stream": False},
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        text = response.json()["response"].strip()
 
-        # Strip markdown code fences if present
         if text.startswith("```"):
             text = text.split("```")[1]
             if text.startswith("json"):
                 text = text[4:]
         return json.loads(text)
     except Exception as exc:
-        print(f"[Gemini] API call failed ({exc}) — using rule-based fallback")
+        print(f"[Gemma] Ollama call failed ({exc}) — using rule-based fallback")
         return None
 
 
@@ -99,7 +94,7 @@ def classify_risk(event: AnomalyEvent) -> RiskAssessment:
         signal_type=event.signal_type,
     )
 
-    result = _call_gemini(prompt) or _rule_based_fallback(event)
+    result = _call_gemma(prompt) or _rule_based_fallback(event)
 
     return RiskAssessment(
         patient_id=event.patient_id,

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,15 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "  CareFlow  ·  LA Hacks 2026"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+# Check Ollama is reachable
+OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+if ! curl -sf "$OLLAMA_HOST" > /dev/null 2>&1; then
+  echo "⚠️   Ollama not detected at $OLLAMA_HOST"
+  echo "    Run in a separate terminal:  ollama serve"
+  echo "    (risk classifier will use rule-based fallback until Ollama is up)"
+  echo ""
+fi
+
 # Seed DB (idempotent — safe to re-run)
 echo "▶ Seeding demo patients…"
 python scripts/seed.py


### PR DESCRIPTION
Summary
Implements the Brain layer of the CareFlow pipeline — converting raw anomaly events into structured clinical risk assessments. Switched the AI backend from Vertex AI (Gemini) to a locally-running Gemma 2B model via Ollama, targeting the MLH x Google Cloud Best Use of Gemma prize track.

Why Gemma instead of Gemini API
Using a locally-running open-weights model strengthens CareFlow's core privacy narrative: not only do raw vitals never leave the device (ZETIC), but AI inference also runs entirely on-premises. No patient data touches an external API. This is a meaningful differentiator for a healthcare application.

Changes
risk/classifier.py — core classification logic, three layers:
- _call_gemma() — sends a structured clinical prompt to gemma2:2b running locally via Ollama's REST API (POST /api/generate), parses the JSON response. Prompt was tightened to suppress markdown output, which smaller models tend to emit.
- _rule_based_fallback() — if Ollama is unreachable, applies HR/SpO2/HRV threshold rules to produce an equivalent RiskAssessment. The rest of the pipeline cannot distinguish between the two paths.
- classify_risk(event) — public entry point called by the Coordinator Agent. Returns a fully-populated RiskAssessment Pydantic model in all cases.

requirements.txt:
- Removed google-cloud-aiplatform and vertexai (no longer needed)
- No new packages added — Ollama is called over HTTP using httpx which was already a dependency
- Bumped uagents from 0.13.0 → 0.24.2 (0.13.0 caps at Python <3.13)
- Relaxed pydantic from ==2.7.4 → >=2.8,<3.0 to resolve conflict with uagents 0.24.2

start.sh — added an Ollama health check at startup that warns if ollama serve isn't running, rather than silently falling back
.env.example — replaced all GCP credential vars (GCP_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS, etc.) with OLLAMA_HOST and GEMMA_MODEL

Setup required on demo machine:
brew install ollama
ollama serve            # keep running in a background terminal
ollama pull gemma2:2b   # ~1.5 GB

Verified working
Tested end-to-end with a synthetic AFib anomaly event (HR=142, SpO2=93.5, HRV=16). Gemma returned severity_level=HIGH with a clinically coherent reasoning_context and doctor_note. Rule-based fallback also tested by stopping Ollama mid-run.